### PR TITLE
refactor: modern product media gallery

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,0 +1,16 @@
+.product-gallery{display:flex;gap:1rem}
+.product-gallery__main{flex:1;display:flex;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;-webkit-overflow-scrolling:touch}
+.product-gallery__slide{flex:0 0 100%;scroll-snap-align:start;position:relative;aspect-ratio:var(--ratio);background:var(--color-media-bg, #f6f6f6)}
+.product-gallery__slide.is-loading::after{content:"";position:absolute;inset:0;background:linear-gradient(90deg,rgba(0,0,0,0.05) 25%,rgba(0,0,0,0.15) 37%,rgba(0,0,0,0.05) 63%);background-size:400% 100%;animation:pg-shimmer 1.4s ease infinite}
+@keyframes pg-shimmer{0%{background-position:100% 0}100%{background-position:-100% 0}}
+.product-gallery__image,.product-gallery__deferred,.product-gallery__deferred>*{width:100%;height:100%;object-fit:contain}
+.product-gallery__thumbs{display:flex;flex-direction:column;gap:.5rem;width:80px;overflow:auto}
+.product-gallery__thumb{border:1px solid transparent;padding:0;background:none;cursor:pointer}
+.product-gallery__thumb[aria-current="true"]{border-color:currentColor}
+.product-gallery__lightbox{padding:0;border:none;max-width:none}
+.product-gallery__lightbox::backdrop{background:rgba(0,0,0,.8)}
+.product-gallery__lightbox-body{max-width:90vw;max-height:90vh;margin:auto}
+.product-gallery__lightbox-body img,.product-gallery__lightbox-body video,.product-gallery__lightbox-body model-viewer,.product-gallery__lightbox-body iframe{width:100%;height:100%;object-fit:contain}
+.product-gallery__lightbox-close{position:absolute;top:1rem;right:1rem;background:none;border:0;color:#fff;font-size:2rem;cursor:pointer}
+@media(max-width:768px){.product-gallery{flex-direction:column}.product-gallery__thumbs{order:2;flex-direction:row;width:100%}.product-gallery__main{order:1}}
+@media(prefers-reduced-motion:reduce){.product-gallery__main{scroll-behavior:auto}}

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -1,0 +1,60 @@
+(function(){
+  class ProductGallery{
+    constructor(el){
+      this.el=el;
+      this.main=el.querySelector('.product-gallery__main');
+      this.slides=Array.from(this.main.children);
+      this.thumbsWrap=el.querySelector('.product-gallery__thumbs');
+      this.thumbs=this.thumbsWrap?Array.from(this.thumbsWrap.querySelectorAll('.product-gallery__thumb')):[];
+      this.lightbox=el.querySelector('.product-gallery__lightbox');
+      this.lightboxBody=this.lightbox?this.lightbox.querySelector('.product-gallery__lightbox-body'):null;
+      this.bind();
+    }
+    bind(){
+      this.thumbs.forEach(t=>t.addEventListener('click',()=>this.scrollToMedia(t.dataset.mediaId)));
+      this.main.addEventListener('scroll',this.onScroll.bind(this),{passive:true});
+      this.slides.forEach(slide=>{
+        const img=slide.querySelector('img');
+        if(img){
+          if(img.complete) slide.classList.remove('is-loading');
+          else img.addEventListener('load',()=>slide.classList.remove('is-loading'),{once:true});
+        }
+        slide.addEventListener('click',()=>this.openLightbox(slide));
+      });
+      if(this.lightbox){
+        const closeBtn=this.lightbox.querySelector('.product-gallery__lightbox-close');
+        if(closeBtn) closeBtn.addEventListener('click',()=>this.lightbox.close());
+        this.lightbox.addEventListener('click',e=>{if(e.target===this.lightbox) this.lightbox.close();});
+      }
+      document.addEventListener('variant:change',this.onVariantChange.bind(this));
+    }
+    onScroll(){
+      const idx=Math.round(this.main.scrollLeft/this.main.clientWidth);
+      const slide=this.slides[idx];
+      if(slide) this.setActiveThumb(slide.dataset.mediaId);
+    }
+    setActiveThumb(id){
+      this.thumbs.forEach(t=>{if(t.dataset.mediaId===id) t.setAttribute('aria-current','true'); else t.removeAttribute('aria-current');});
+    }
+    scrollToMedia(id){
+      const slide=this.slides.find(s=>s.dataset.mediaId==id);
+      if(slide){slide.scrollIntoView({behavior:'smooth',block:'nearest',inline:'center'});this.setActiveThumb(id);}
+    }
+    onVariantChange(e){
+      const media=e.detail && e.detail.variant && e.detail.variant.featured_media;
+      if(media) this.scrollToMedia(String(media.id));
+    }
+    openLightbox(slide){
+      if(!this.lightbox) return;
+      const clone=slide.cloneNode(true);
+      clone.classList.remove('is-loading');
+      this.lightboxBody.innerHTML='';
+      this.lightboxBody.appendChild(clone);
+      this.lightbox.showModal();
+    }
+  }
+  document.addEventListener('DOMContentLoaded',()=>{
+    document.querySelectorAll('product-media-gallery').forEach(el=>new ProductGallery(el));
+  });
+  if(typeof module!=='undefined') module.exports=ProductGallery;
+})();

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -15,7 +15,7 @@
 {%- endif -%}
 
 {%- if product.media.size > 0 -%}
-  <link rel="stylesheet" href="{{ 'media-gallery.css' | asset_url }}">
+  <link rel="stylesheet" href="{{ 'product-gallery.css' | asset_url }}">
 {%- endif -%}
 
 {%- if product.metafields.reviews.rating.value != blank -%}
@@ -32,6 +32,7 @@
 {%- endif -%}
 
 <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-gallery.js' | asset_url }}" defer></script>
 
 {%- liquid
   # constants
@@ -100,19 +101,7 @@
   <div class="product js-product" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
       {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
+        {%- render 'product-media-gallery', product: product, enable_zoom: true, show_thumbs: true -%}
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,0 +1,67 @@
+{% comment %}Simplified product media gallery{% endcomment %}
+{% assign gallery_id = 'product-gallery-' | append: product.id %}
+<product-media-gallery id="{{ gallery_id }}" class="product-gallery" data-product-id="{{ product.id }}">
+  <div class="product-gallery__main">
+    {% for media in product.media %}
+      {%- assign ratio = media.preview_image.aspect_ratio | default: 1 -%}
+      <div class="product-gallery__slide is-loading" data-media-id="{{ media.id }}" style="--ratio:{{ ratio }}">
+        {% case media.media_type %}
+          {% when 'image' %}
+            <img
+              src="{{ media | image_url: width: 1500 }}"
+              srcset="{{ media | image_url: width: 400 }} 400w, {{ media | image_url: width: 800 }} 800w, {{ media | image_url: width: 1200 }} 1200w, {{ media | image_url: width: 1500 }} 1500w"
+              sizes="(min-width: 768px) 80vw, 100vw"
+              width="{{ media.preview_image.width }}"
+              height="{{ media.preview_image.height }}"
+              alt="{{ media.alt | escape | default: product.title }}"
+              {% if forloop.first %}fetchpriority="high"{% else %}loading="lazy"{% endif %}
+              class="product-gallery__image" />
+          {% when 'video' %}
+            <deferred-media class="product-gallery__deferred" data-media-id="{{ media.id }}">
+              <button class="product-gallery__poster" type="button">
+                <img src="{{ media.preview_image | image_url: width: 800 }}" alt="{{ media.alt | escape | default: product.title }}" />
+              </button>
+              <template>
+                {{ media | video_tag: controls: true }}
+              </template>
+            </deferred-media>
+          {% when 'external_video' %}
+            <deferred-media class="product-gallery__deferred" data-media-id="{{ media.id }}">
+              <button class="product-gallery__poster" type="button">
+                <img src="{{ media.preview_image | image_url: width: 800 }}" alt="{{ media.alt | escape | default: product.title }}" />
+              </button>
+              <template>
+                {{ media | external_video_tag }}
+              </template>
+            </deferred-media>
+          {% when 'model' %}
+            <deferred-media class="product-gallery__deferred" data-media-id="{{ media.id }}">
+              <button class="product-gallery__poster" type="button">
+                <img src="{{ media.preview_image | image_url: width: 800 }}" alt="{{ media.alt | escape | default: product.title }}" />
+              </button>
+              <template>
+                {{ media | model_viewer_tag }}
+              </template>
+            </deferred-media>
+        {% endcase %}
+      </div>
+    {% endfor %}
+  </div>
+  {% if show_thumbs %}
+  <div class="product-gallery__thumbs">
+    {% for media in product.media %}
+      <button class="product-gallery__thumb" data-media-id="{{ media.id }}" aria-label="{{ 'products.product.media.thumbnail' | t }} {{ forloop.index }}">
+        {% if media.media_type == 'video' or media.media_type == 'external_video' or media.media_type == 'model' %}
+          {{ media.preview_image | image_url: width: 100 | image_tag: width: 100, height: 100, alt: media.alt | escape }}
+        {% else %}
+          {{ media | image_url: width: 100 | image_tag: width: 100, height: 100, alt: media.alt | escape }}
+        {% endif %}
+      </button>
+    {% endfor %}
+  </div>
+  {% endif %}
+  <dialog class="product-gallery__lightbox" aria-label="{{ product.title }}">
+    <button type="button" class="product-gallery__lightbox-close" aria-label="{{ 'accessibility.close' | t }}">&times;</button>
+    <div class="product-gallery__lightbox-body"></div>
+  </dialog>
+</product-media-gallery>

--- a/tests/product-gallery.test.js
+++ b/tests/product-gallery.test.js
@@ -1,0 +1,27 @@
+const assert=require('assert');
+let variantHandler;
+const listeners={};
+// Minimal DOM stubs
+global.document={
+  addEventListener:(ev,cb)=>{listeners[ev]=cb; if(ev==='variant:change') variantHandler=cb;},
+  querySelectorAll:()=>[]
+};
+global.window={};
+const ProductGallery=require('../assets/product-gallery.js');
+function createSlide(id){return{dataset:{mediaId:String(id)},scrollIntoView(){this.called=true;},called:false,querySelector:(sel)=>sel==='img'?{complete:true,addEventListener(){}}:null,addEventListener(){},classList:{remove(){}},cloneNode(){return this;}}}
+const slide1=createSlide(1);const slide2=createSlide(2);
+const galleryEl={
+  querySelector:(sel)=>{
+    if(sel==='.product-gallery__main') return {children:[slide1,slide2],addEventListener(){},clientWidth:100,scrollLeft:0};
+    if(sel==='.product-gallery__thumbs') return {querySelectorAll:()=>[]};
+    return null;
+  }
+};
+const gallery=new ProductGallery(galleryEl);
+assert.strictEqual(gallery.slides.length,2,'two slides initialized');
+gallery.scrollToMedia('2');
+assert.ok(slide2.called,'slide2 scrolled into view');
+// simulate variant change
+variantHandler({detail:{variant:{featured_media:{id:'1'}}}});
+assert.ok(slide1.called,'variant change scrolls to slide1');
+console.log('ProductGallery tests passed');


### PR DESCRIPTION
## Summary
- replace legacy media gallery with new `product-media-gallery` snippet
- add responsive scroll-snap layout and lightbox via `product-gallery.css` and `product-gallery.js`
- include unit test for variant->media sync

## Testing
- `node tests/product-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5670fd8088326a17acda1d4f3103c