### PR TITLE
refactor: modern product media gallery

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,0 +1,82 @@
+.product-gallery {
+  display: grid;
+  gap: 1rem;
+}
+
+.product-gallery__viewer {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+.product-gallery__media {
+  flex: 0 0 100%;
+  scroll-snap-align: center;
+  position: relative;
+}
+.product-gallery__img,
+.deferred-media__poster img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: var(--media-aspect, 1/1);
+  background: #f5f5f5;
+  object-fit: cover;
+}
+
+.product-gallery__thumbs {
+  display: flex;
+  gap: .5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+}
+.product-gallery__thumb {
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+}
+.product-gallery__thumb[aria-current="true"] {
+  outline: 2px solid currentColor;
+}
+
+@media (min-width: 768px) {
+  .product-gallery {
+    grid-template-columns: 100px 1fr;
+    align-items: start;
+  }
+  .product-gallery__thumbs {
+    flex-direction: column;
+    max-height: 600px;
+    overflow-y: auto;
+  }
+  .product-gallery__viewer {
+    order: 2;
+  }
+}
+
+.product-gallery__lightbox {
+  width: 100vw;
+  height: 100vh;
+  padding: 0;
+  border: none;
+  background: rgba(0,0,0,.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.product-gallery__lightbox::backdrop {
+  background: rgba(0,0,0,.9);
+}
+.product-gallery__lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+}

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -1,0 +1,59 @@
+class ProductGallery {
+  constructor(container) {
+    this.container = container;
+    this.viewer = container.querySelector('.product-gallery__viewer');
+    this.thumbs = Array.from(container.querySelectorAll('.product-gallery__thumb'));
+    this.dialog = container.querySelector('dialog');
+    this.registerEvents();
+  }
+
+  prefersReduced() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
+  registerEvents() {
+    this.thumbs.forEach((btn, index) => {
+      btn.addEventListener('click', () => {
+        this.showSlide(index);
+      });
+    });
+
+    this.viewer.addEventListener('click', (e) => {
+      const slide = e.target.closest('.product-gallery__media');
+      if (!slide) return;
+      this.openLightbox(slide.cloneNode(true));
+    });
+
+    this.dialog.querySelector('.product-gallery__lightbox-close').addEventListener('click', () => {
+      this.dialog.close();
+    });
+
+    document.addEventListener('variant:change', (e) => {
+      const id = e.detail?.variant?.featured_media?.id;
+      if (id) this.scrollToMedia(id);
+    });
+  }
+
+  showSlide(index) {
+    const slide = this.viewer.children[index];
+    slide.scrollIntoView({behavior: this.prefersReduced() ? 'auto' : 'smooth'});
+    this.thumbs.forEach(t => t.removeAttribute('aria-current'));
+    this.thumbs[index].setAttribute('aria-current', 'true');
+  }
+
+  scrollToMedia(id) {
+    const slide = this.viewer.querySelector(`[data-media-id="${id}"]`);
+    if (slide) slide.scrollIntoView({behavior: this.prefersReduced() ? 'auto' : 'smooth'});
+  }
+
+  openLightbox(node) {
+    this.dialog.innerHTML = '<button type="button" class="product-gallery__lightbox-close" aria-label="Close">&times;</button>';
+    this.dialog.appendChild(node);
+    this.dialog.showModal();
+    this.dialog.querySelector('.product-gallery__lightbox-close').addEventListener('click', () => this.dialog.close(), {once:true});
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-product-gallery]').forEach(el => new ProductGallery(el));
+});

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -15,7 +15,8 @@
 {%- endif -%}
 
 {%- if product.media.size > 0 -%}
-  <link rel="stylesheet" href="{{ 'media-gallery.css' | asset_url }}">
+  {{ 'product-gallery.css' | asset_url | stylesheet_tag }}
+  <script src="{{ 'product-gallery.js' | asset_url }}" defer></script>
 {%- endif -%}
 
 {%- if product.metafields.reviews.rating.value != blank -%}
@@ -73,16 +74,6 @@
 -%}
 
 {%- style -%}
-  {%- if section.settings.media_layout == 'stacked' -%}
-    @media (max-width:  {{ breakpoint_md | minus: 0.02 }}px) {
-      .media-gallery__main .media-xr-button { display: none; }
-      .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-    }
-  {%- else -%}
-    .media-gallery__main .media-xr-button { display: none; }
-    .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-  {%- endif -%}
-
   {%- if section.settings.media_size == 'large' -%}
     @media (min-width: {{ breakpoint_lg }}px) {
       :root { --product-info-width: 800px !important; }
@@ -100,19 +91,7 @@
   <div class="product js-product" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
       {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
+        {%- render 'product-media-gallery', product: product, enable_zoom: true, show_thumbs: true -%}
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,0 +1,74 @@
+{% comment %}
+  Product media gallery component
+  Supports images, videos, external videos, and 3D models
+{% endcomment %}
+
+{%- liquid
+  assign enable_zoom = enable_zoom | default: false
+  assign show_thumbs = show_thumbs | default: true
+-%}
+
+{%- assign first_media = product.media | first -%}
+<div class="product-gallery" data-product-gallery>
+  <div class="product-gallery__viewer" aria-live="polite">
+    {%- for media in product.media -%}
+      <div class="product-gallery__media" id="Media-{{ media.id }}" data-media-id="{{ media.id }}">
+        {%- case media.media_type -%}
+          {%- when 'image' -%}
+            {%- assign src = media | image_url: width: 1440 -%}
+            <img
+              src="{{ src }}"
+              srcset="{{ media | image_srcset }}"
+              sizes="(min-width: 1024px) 800px, 100vw"
+              width="{{ media.width }}"
+              height="{{ media.height }}"
+              alt="{{ media.alt | escape | default: product.title | escape }}"
+              {% if forloop.first %}fetchpriority="high"{% else %}loading="lazy"{% endif %}
+              class="product-gallery__img"
+            >
+          {%- when 'video' -%}
+            <deferred-media class="deferred-media" data-media-id="{{ media.id }}">
+              <template>
+                {{ media | media_tag: image_size: '1440x' }}
+              </template>
+              <button class="deferred-media__poster" type="button">
+                {{ media.preview_image | image_url: width: 1440 | image_tag: width: media.preview_image.width, height: media.preview_image.height, loading: 'lazy', alt: media.alt | escape | default: product.title | escape }}
+              </button>
+            </deferred-media>
+          {%- when 'external_video' -%}
+            <deferred-media class="deferred-media" data-media-id="{{ media.id }}">
+              <template>
+                {{ media | external_video_tag }}
+              </template>
+              <button class="deferred-media__poster" type="button">
+                {{ media.preview_image | image_url: width: 1440 | image_tag: width: media.preview_image.width, height: media.preview_image.height, loading: 'lazy', alt: media.alt | escape | default: product.title | escape }}
+              </button>
+            </deferred-media>
+          {%- when 'model' -%}
+            <deferred-media class="deferred-media" data-media-id="{{ media.id }}">
+              <template>
+                {{ media | model_viewer_tag: image_size: '1440x', reveal: 'interaction', toggleable: true }}
+              </template>
+              <button class="deferred-media__poster" type="button">
+                {{ media.preview_image | image_url: width: 1440 | image_tag: width: media.preview_image.width, height: media.preview_image.height, loading: 'lazy', alt: media.alt | escape | default: product.title | escape }}
+              </button>
+            </deferred-media>
+        {%- endcase -%}
+      </div>
+    {%- endfor -%}
+  </div>
+
+  {%- if show_thumbs -%}
+    <div class="product-gallery__thumbs" aria-label="{{ 'products.product.media' | t }}">
+      {%- for media in product.media -%}
+        <button class="product-gallery__thumb" data-media-id="{{ media.id }}" aria-controls="Media-{{ media.id }}" aria-label="{{ media.alt | escape | default: product.title | escape }}" {% if forloop.first %}aria-current="true"{% endif %}>
+          {{ media.preview_image | image_url: width: 200 | image_tag: width: media.preview_image.width, height: media.preview_image.height, loading: 'lazy', alt: '' }}
+        </button>
+      {%- endfor -%}
+    </div>
+  {%- endif -%}
+
+  <dialog class="product-gallery__lightbox" aria-label="{{ product.title | escape }}">
+    <button type="button" class="product-gallery__lightbox-close" aria-label="{{ 'accessibility.close' | t }}">&times;</button>
+  </dialog>
+</div>

--- a/tests/product-gallery.test.js
+++ b/tests/product-gallery.test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const snippet = fs.readFileSync('snippets/product-media-gallery.liquid', 'utf8');
+assert(snippet.includes('data-product-gallery'), 'data-product-gallery missing');
+assert(snippet.includes('deferred-media'), 'deferred-media missing');
+
+const js = fs.readFileSync('assets/product-gallery.js', 'utf8');
+assert(/class ProductGallery/.test(js), 'ProductGallery class missing');
+assert(js.includes('variant:change'), 'variant change listener missing');
+
+const css = fs.readFileSync('assets/product-gallery.css', 'utf8');
+assert(css.includes('scroll-snap-type'), 'scroll-snap-type missing');
+
+console.log('All product gallery tests passed');


### PR DESCRIPTION
## Summary
- replace legacy media gallery with responsive, accessible scroll-snap component
- add product-gallery CSS/JS with lazy loading, lightbox, and variant syncing
- update main-product section to load new gallery

## Testing
- `node tests/product-gallery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5670fd8088326a17acda1d4f3103c