### PR TITLE
feat: redesign product gallery

### DIFF
--- a/assets/media-gallery.css
+++ b/assets/media-gallery.css
@@ -35,8 +35,8 @@
 }
 
 .media-gallery__viewer {
-  border: 1px solid var(--gallery-border-color);
-  background-color: var(--gallery-bg-color);
+  border: none;
+  background-color: transparent;
 }
 
 .media-viewer,
@@ -68,6 +68,9 @@
   flex: 0 0 100%;
   text-align: center;
 }
+.media-viewer__item .media {
+  aspect-ratio: 1 / 1;
+}
 .media-viewer__item > deferred-media[loaded] {
   z-index: 3;
 }
@@ -92,10 +95,16 @@
 
 .media-gallery__thumbs {
   margin-top: var(--media-gap);
+  display: flex;
+  justify-content: center;
 }
 
 .media-thumbs__item {
   flex: 0 0 84px;
+}
+
+.media-thumbs {
+  justify-content: center;
 }
 
 .media-thumbs__btn {

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -109,8 +109,7 @@
 
 @media (min-width: 1024px) {
   .product-main .product-media {
-    position: sticky;
-    top: var(--header-end-padded, 70px);
+    position: static;
   }
 }
 
@@ -126,6 +125,21 @@
   background-color: #fff;
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.product-gallery-card {
+  text-align: center;
+  padding: 32px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+@media (min-width: 1024px) {
+  .product-gallery-card {
+    position: sticky;
+    top: var(--header-end-padded, 70px);
+  }
 }
 
 .product-info-card > .product-info__block {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -100,19 +100,21 @@
   <div class="product js-product" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
       {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
+        <div class="product-gallery-card">
+          {% render 'media-gallery',
+            product: product,
+            featured_media: featured_media,
+            media_ratio: media_ratio,
+            media_crop: section.settings.media_crop,
+            thumb_ratio: thumb_ratio,
+            thumb_crop: section.settings.thumb_crop,
+            first_3d_model: first_3d_model,
+            enable_zoom: section.settings.enable_zoom,
+            enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
+            zoom_mode: section.settings.zoom_mode,
+            zoom_level: section.settings.hover_zoom
+          %}
+        </div>
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}


### PR DESCRIPTION
## Summary
- wrap product media in a sticky `product-gallery-card` to match the info box
- center thumbnail navigation and enforce consistent square media display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b56b2a2d3883268f297ed6bb1a1a80