### PR TITLE
Redesign product media gallery

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,0 +1,45 @@
+.product-gallery{
+  position:sticky;
+  top:0;
+}
+.product-gallery__viewer{
+  width:100%;
+  aspect-ratio:var(--aspect-ratio);
+  border-radius:8px;
+  overflow:hidden;
+  box-shadow:0 2px 8px rgba(0,0,0,0.1);
+}
+.product-gallery__image{
+  width:100%;
+  height:100%;
+  object-fit:contain;
+  display:none;
+}
+.product-gallery__image.is-active{display:block;}
+.product-gallery__thumbs{
+  margin-top:0.5rem;
+  display:flex;
+  justify-content:center;
+  gap:0.5rem;
+  overflow-x:auto;
+  scroll-snap-type:x mandatory;
+  padding:0;
+}
+.product-gallery__thumb-item{list-style:none;}
+.product-gallery__thumb{
+  border:0;
+  background:none;
+  padding:0;
+  cursor:pointer;
+  scroll-snap-align:center;
+}
+.product-gallery__thumb img{
+  width:60px;
+  height:60px;
+  object-fit:contain;
+  border-radius:6px;
+  box-shadow:0 1px 4px rgba(0,0,0,0.1);
+}
+.product-gallery__thumb.is-active img{
+  outline:2px solid var(--link-color);
+}

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const gallery=document.querySelector('.product-gallery');
+  if(!gallery) return;
+  const images=[...gallery.querySelectorAll('.product-gallery__image')];
+  const thumbs=[...gallery.querySelectorAll('.product-gallery__thumb')];
+  let index=0;
+  function show(i){
+    images[index].classList.remove('is-active');
+    thumbs[index].classList.remove('is-active');
+    index=i;
+    images[index].classList.add('is-active');
+    thumbs[index].classList.add('is-active');
+    thumbs[index].scrollIntoView({behavior:'smooth',inline:'center',block:'nearest'});
+  }
+  thumbs.forEach((btn,i)=>btn.addEventListener('click',()=>show(i)));
+  gallery.addEventListener('keydown',e=>{
+    if(e.key==='ArrowRight'){show((index+1)%images.length);e.preventDefault();}
+    else if(e.key==='ArrowLeft'){show((index-1+images.length)%images.length);e.preventDefault();}
+    else if(e.key==='Home'){show(0);e.preventDefault();}
+    else if(e.key==='End'){show(images.length-1);e.preventDefault();}
+  });
+});

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -258,6 +258,11 @@
   <link rel="stylesheet" href="{{ 'main.css' | asset_url }}">
   <script src="{{ 'main.js' | asset_url }}" defer="defer"></script>
 
+  {% if request.page_type == 'product' %}
+    <link rel="stylesheet" href="{{ 'product-gallery.css' | asset_url }}">
+    <script src="{{ 'product-gallery.js' | asset_url }}" defer="defer"></script>
+  {% endif %}
+
   {%- if request.page_type contains 'customers' -%}
     <link rel="stylesheet" href="{{ 'customer.css' | asset_url }}">
   {%- endif -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -14,9 +14,6 @@
   {{ 'reviews.css' | asset_url | stylesheet_tag }}
 {%- endif -%}
 
-{%- if product.media.size > 0 -%}
-  <link rel="stylesheet" href="{{ 'media-gallery.css' | asset_url }}">
-{%- endif -%}
 
 {%- if product.metafields.reviews.rating.value != blank -%}
   <script>
@@ -50,45 +47,9 @@
 
   assign product_form_id = 'product-form-' | append: section.id
   assign first_3d_model = product.media | where: 'media_type', 'model' | first
-  assign media_ratio = section.settings.media_ratio
-  assign thumb_ratio = section.settings.thumb_ratio
-
-  if media_ratio == 'natural'
-    assign media_ratio = 99
-    for media in product.media
-      if media.preview_image.aspect_ratio < media_ratio
-        assign media_ratio = media.preview_image.aspect_ratio
-      endif
-    endfor
-  endif
-
-  if thumb_ratio == 'natural'
-    assign thumb_ratio = 99
-    for media in product.media
-      if media.preview_image.aspect_ratio < thumb_ratio
-        assign thumb_ratio = media.preview_image.aspect_ratio
-      endif
-    endfor
-  endif
+  assign media_ratio = product.media.first.preview_image.aspect_ratio | default: 1
 -%}
 
-{%- style -%}
-  {%- if section.settings.media_layout == 'stacked' -%}
-    @media (max-width:  {{ breakpoint_md | minus: 0.02 }}px) {
-      .media-gallery__main .media-xr-button { display: none; }
-      .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-    }
-  {%- else -%}
-    .media-gallery__main .media-xr-button { display: none; }
-    .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-  {%- endif -%}
-
-  {%- if section.settings.media_size == 'large' -%}
-    @media (min-width: {{ breakpoint_lg }}px) {
-      :root { --product-info-width: 800px !important; }
-    }
-  {%- endif -%}
-{%- endstyle -%}
 
 {%- if first_3d_model -%}
   <link rel="stylesheet" href="https://cdn.shopify.com/shopifycloud/model-viewer-ui/assets/v1.0/model-viewer-ui.css" media="print" onload="this.media='all'">
@@ -99,25 +60,13 @@
 <div class="container">
   <div class="product js-product" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
-      {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
-      {%- else -%}
+      {% if product.media.size > 0 %}
+        {% render 'product-media-gallery', product: product %}
+      {% else %}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
         </div>
-      {%- endif -%}
+      {% endif %}
     </div>
 
     <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,0 +1,17 @@
+{% assign aspect = product.media.first.preview_image.aspect_ratio | default: 1 %}
+<div class="product-gallery" style="--aspect-ratio: {{ aspect }}" tabindex="0">
+  <div class="product-gallery__viewer">
+    {% for media in product.media %}
+      <img src="{{ media | image_url }}" alt="{{ media.alt | escape }}" class="product-gallery__image{% if forloop.first %} is-active{% endif %}" data-media-index="{{ forloop.index0 }}">
+    {% endfor %}
+  </div>
+  <ul class="product-gallery__thumbs" role="list">
+    {% for media in product.media %}
+      <li class="product-gallery__thumb-item">
+        <button type="button" class="product-gallery__thumb{% if forloop.first %} is-active{% endif %}" data-media-index="{{ forloop.index0 }}">
+          <img src="{{ media | image_url: width: 200 }}" alt="{{ media.alt | escape }}">
+        </button>
+      </li>
+    {% endfor %}
+  </ul>
+</div>


### PR DESCRIPTION
## Summary
- replace previous media gallery with new `product-media-gallery` snippet
- add sticky product image gallery with centered thumbnails
- load new gallery assets and enable thumbnail-driven navigation

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b57437815483268e42706fe22998e1