### PR TITLE
feat: redesign product media gallery

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,0 +1,61 @@
+.product-gallery {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+}
+
+.product-gallery__main {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-bottom: 1rem;
+}
+
+.product-gallery__image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: none;
+}
+
+.product-gallery__image.is-active {
+  display: block;
+}
+
+.product-gallery__thumbs {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  justify-content: center;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 0.5rem;
+}
+
+.product-gallery__thumbs::-webkit-scrollbar {
+  display: none;
+}
+
+.product-gallery__thumb {
+  flex: 0 0 auto;
+  width: 80px;
+  aspect-ratio: 1 / 1;
+  border: 2px solid transparent;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  padding: 0;
+  background: none;
+  scroll-snap-align: center;
+}
+
+.product-gallery__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+.product-gallery__thumb.is-active {
+  border-color: var(--link-color, #000);
+}

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -1,0 +1,48 @@
+(function() {
+  function init() {
+    var gallery = document.querySelector('.product-gallery');
+    if (!gallery) return;
+    var images = gallery.querySelectorAll('.product-gallery__image');
+    var thumbs = gallery.querySelectorAll('.product-gallery__thumb');
+    var index = 0;
+
+    function show(i) {
+      if (i < 0 || i >= images.length) return;
+      images[index].classList.remove('is-active');
+      thumbs[index].classList.remove('is-active');
+      index = i;
+      images[index].classList.add('is-active');
+      thumbs[index].classList.add('is-active');
+      thumbs[index].scrollIntoView({behavior: 'smooth', inline: 'center', block: 'nearest'});
+    }
+
+    thumbs.forEach(function(thumb, i) {
+      thumb.addEventListener('click', function() {
+        show(i);
+      });
+    });
+
+    gallery.addEventListener('keydown', function(e) {
+      switch (e.key) {
+        case 'ArrowRight':
+          e.preventDefault();
+          show((index + 1) % images.length);
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          show((index - 1 + images.length) % images.length);
+          break;
+        case 'Home':
+          e.preventDefault();
+          show(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          show(images.length - 1);
+          break;
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -267,6 +267,11 @@
     <noscript><link rel="stylesheet" href="{{ 'swatches.css' | asset_url }}"></noscript>
   {%- endif -%}
 
+  {%- if request.page_type == 'product' -%}
+    <link rel="stylesheet" href="{{ 'product-gallery.css' | asset_url }}">
+    <script src="{{ 'product-gallery.js' | asset_url }}" defer="defer"></script>
+  {%- endif -%}
+
   {{ content_for_header }}
 
   {%- if request.design_mode -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -14,10 +14,6 @@
   {{ 'reviews.css' | asset_url | stylesheet_tag }}
 {%- endif -%}
 
-{%- if product.media.size > 0 -%}
-  <link rel="stylesheet" href="{{ 'media-gallery.css' | asset_url }}">
-{%- endif -%}
-
 {%- if product.metafields.reviews.rating.value != blank -%}
   <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -51,7 +47,6 @@
   assign product_form_id = 'product-form-' | append: section.id
   assign first_3d_model = product.media | where: 'media_type', 'model' | first
   assign media_ratio = section.settings.media_ratio
-  assign thumb_ratio = section.settings.thumb_ratio
 
   if media_ratio == 'natural'
     assign media_ratio = 99
@@ -61,28 +56,9 @@
       endif
     endfor
   endif
-
-  if thumb_ratio == 'natural'
-    assign thumb_ratio = 99
-    for media in product.media
-      if media.preview_image.aspect_ratio < thumb_ratio
-        assign thumb_ratio = media.preview_image.aspect_ratio
-      endif
-    endfor
-  endif
 -%}
 
 {%- style -%}
-  {%- if section.settings.media_layout == 'stacked' -%}
-    @media (max-width:  {{ breakpoint_md | minus: 0.02 }}px) {
-      .media-gallery__main .media-xr-button { display: none; }
-      .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-    }
-  {%- else -%}
-    .media-gallery__main .media-xr-button { display: none; }
-    .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-  {%- endif -%}
-
   {%- if section.settings.media_size == 'large' -%}
     @media (min-width: {{ breakpoint_lg }}px) {
       :root { --product-info-width: 800px !important; }
@@ -98,21 +74,9 @@
 
 <div class="container">
   <div class="product js-product" data-section="{{ section.id }}">
-    <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
+    <div id="product-media" class="product-media">
       {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
+        {% render 'product-media-gallery', product: product %}
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,0 +1,21 @@
+{% comment %}New product media gallery{% endcomment %}
+<div class="product-gallery" tabindex="0">
+  <div class="product-gallery__main">
+    {% for media in product.media %}
+      <img
+        src="{{ media | image_url }}"
+        alt="{{ media.alt | escape }}"
+        class="product-gallery__image{% if forloop.first %} is-active{% endif %}"
+        data-index="{{ forloop.index0 }}">
+    {% endfor %}
+  </div>
+  {% if product.media.size > 1 %}
+  <div class="product-gallery__thumbs">
+    {% for media in product.media %}
+      <button class="product-gallery__thumb{% if forloop.first %} is-active{% endif %}" type="button" data-index="{{ forloop.index0 }}" aria-label="{{ 'products.product.media.thumbnail' | t }}">
+        <img src="{{ media | image_url: width: 180 }}" alt="{{ media.alt | escape }}">
+      </button>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- implement new `product-media-gallery` snippet with scrollable thumbnails
- add sticky gallery styling and navigation script
- load gallery assets only on product pages

## Testing
- `npm test` *(fails: package.json missing)*
- `theme check` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57437815483268e42706fe22998e1