### PR TITLE
Implement sticky product media gallery

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,0 +1,48 @@
+.product-gallery {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+}
+.product-gallery__main {
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+.product-gallery__media {
+  display: none;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+}
+.product-gallery__media.is-active {
+  display: block;
+}
+.product-gallery__image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.product-gallery__thumbs {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  justify-content: center;
+}
+.product-gallery__thumb {
+  flex: 0 0 auto;
+  padding: 0;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  background: none;
+  scroll-snap-align: center;
+}
+.product-gallery__thumb.is-active {
+  border-color: #000;
+}
+.product-gallery__thumb-image {
+  width: 60px;
+  height: 60px;
+  object-fit: contain;
+  border-radius: 4px;
+}

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const gallery = document.querySelector('[data-product-gallery]');
+  if (!gallery) return;
+  const mains = Array.from(gallery.querySelectorAll('.product-gallery__media'));
+  const thumbs = Array.from(gallery.querySelectorAll('.product-gallery__thumb'));
+  let index = mains.findIndex(el => el.classList.contains('is-active'));
+  const activate = newIndex => {
+    if (newIndex < 0 || newIndex >= mains.length) return;
+    mains[index].classList.remove('is-active');
+    thumbs[index].classList.remove('is-active');
+    index = newIndex;
+    mains[index].classList.add('is-active');
+    thumbs[index].classList.add('is-active');
+    thumbs[index].scrollIntoView({behavior:'smooth', inline:'center', block:'nearest'});
+  };
+  thumbs.forEach((thumb, i) => {
+    thumb.addEventListener('click', () => activate(i));
+  });
+  gallery.addEventListener('keydown', e => {
+    switch (e.key) {
+      case 'ArrowLeft':
+        e.preventDefault();
+        activate(index - 1);
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        activate(index + 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        activate(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        activate(mains.length - 1);
+        break;
+    }
+  });
+});

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -24,6 +24,11 @@
   {%- render 'doc-head-core' -%}
   {%- render 'doc-head-social' -%}
 
+  {%- if request.page_type == 'product' -%}
+    {{ 'product-gallery.css' | asset_url | stylesheet_tag }}
+    <script src="{{ 'product-gallery.js' | asset_url }}" defer></script>
+  {%- endif -%}
+
   {%- style %}
     {{- settings.body_font | font_face: font_display: 'swap' -}}
     {{- body_font_bold | font_face: font_display: 'swap' -}}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -14,9 +14,7 @@
   {{ 'reviews.css' | asset_url | stylesheet_tag }}
 {%- endif -%}
 
-{%- if product.media.size > 0 -%}
-  <link rel="stylesheet" href="{{ 'media-gallery.css' | asset_url }}">
-{%- endif -%}
+{%- comment -%}Old media gallery styles removed; new gallery assets loaded globally{%- endcomment -%}
 
 {%- if product.metafields.reviews.rating.value != blank -%}
   <script>
@@ -73,16 +71,6 @@
 -%}
 
 {%- style -%}
-  {%- if section.settings.media_layout == 'stacked' -%}
-    @media (max-width:  {{ breakpoint_md | minus: 0.02 }}px) {
-      .media-gallery__main .media-xr-button { display: none; }
-      .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-    }
-  {%- else -%}
-    .media-gallery__main .media-xr-button { display: none; }
-    .active .media-xr-button:not([data-shopify-xr-hidden]) { display: block; }
-  {%- endif -%}
-
   {%- if section.settings.media_size == 'large' -%}
     @media (min-width: {{ breakpoint_lg }}px) {
       :root { --product-info-width: 800px !important; }
@@ -90,29 +78,12 @@
   {%- endif -%}
 {%- endstyle -%}
 
-{%- if first_3d_model -%}
-  <link rel="stylesheet" href="https://cdn.shopify.com/shopifycloud/model-viewer-ui/assets/v1.0/model-viewer-ui.css" media="print" onload="this.media='all'">
-  <link rel="stylesheet" href="{{ 'model-viewer.css' | asset_url }}" media="print" onload="this.media='all'">
-  <script src="{{ 'product-model.js' | asset_url }}" defer></script>
-{%- endif -%}
 
 <div class="container">
   <div class="product js-product" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
       {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
+        {% render 'product-media-gallery', product: product %}
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,0 +1,16 @@
+<div class="product-gallery" data-product-gallery tabindex="0">
+  <div class="product-gallery__main">
+    {%- for media in product.media -%}
+      <div class="product-gallery__media{% if forloop.first %} is-active{% endif %}" data-media-id="{{ media.id }}">
+        {{ media | image_url: width: 1200 | image_tag: loading: 'lazy', class: 'product-gallery__image', alt: media.alt | escape }}
+      </div>
+    {%- endfor -%}
+  </div>
+  <div class="product-gallery__thumbs">
+    {%- for media in product.media -%}
+      <button type="button" class="product-gallery__thumb{% if forloop.first %} is-active{% endif %}" data-media-id="{{ media.id }}">
+        {{ media | image_url: width: 200 | image_tag: loading: 'lazy', class: 'product-gallery__thumb-image', alt: media.alt | escape }}
+      </button>
+    {%- endfor -%}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- replace legacy media rendering with new `product-media-gallery` snippet
- add sticky, responsive gallery styles and interactive thumbnail navigation
- load new gallery assets on product pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b57437815483268e42706fe22998e1