### PR TITLE
feat: redesign product media gallery

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,0 +1,63 @@
+.product-gallery {
+  position: sticky;
+  top: 2rem;
+}
+
+.product-gallery__stage {
+  width: 100%;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  background: #fff;
+}
+
+.product-gallery__image {
+  display: none;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  background: #fff;
+}
+
+.product-gallery__image.is-active {
+  display: block;
+}
+
+.product-gallery__thumbs {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 0.5rem;
+}
+
+.product-gallery__thumb {
+  flex: 0 0 auto;
+  scroll-snap-align: center;
+  border: 2px solid transparent;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  background: #fff;
+}
+
+.product-gallery__thumb.is-active {
+  border-color: var(--link-color, #000);
+}
+
+.product-gallery__thumb img {
+  display: block;
+  width: 64px;
+  height: 64px;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+}
+
+.product-gallery__placeholder svg {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  display: block;
+}

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-product-gallery]').forEach(gallery => {
+    const images = gallery.querySelectorAll('[data-gallery-image]');
+    const thumbs = gallery.querySelectorAll('[data-gallery-target]');
+    let active = 0;
+
+    const show = index => {
+      if (index < 0 || index >= images.length) return;
+      images[active].classList.remove('is-active');
+      thumbs[active].classList.remove('is-active');
+      active = index;
+      images[active].classList.add('is-active');
+      thumbs[active].classList.add('is-active');
+      thumbs[active].scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+    };
+
+    thumbs.forEach((thumb, i) => {
+      thumb.addEventListener('click', () => show(i));
+    });
+
+    gallery.addEventListener('keydown', e => {
+      switch (e.key) {
+        case 'ArrowRight':
+          show((active + 1) % images.length);
+          break;
+        case 'ArrowLeft':
+          show((active - 1 + images.length) % images.length);
+          break;
+        case 'Home':
+          show(0);
+          break;
+        case 'End':
+          show(images.length - 1);
+          break;
+      }
+    });
+
+    gallery.setAttribute('tabindex', '0');
+  });
+});

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -258,6 +258,9 @@
   <link rel="stylesheet" href="{{ 'main.css' | asset_url }}">
   <script src="{{ 'main.js' | asset_url }}" defer="defer"></script>
 
+  <link rel="stylesheet" href="{{ 'product-gallery.css' | asset_url }}">
+  <script src="{{ 'product-gallery.js' | asset_url }}" defer="defer"></script>
+
   {%- if request.page_type contains 'customers' -%}
     <link rel="stylesheet" href="{{ 'customer.css' | asset_url }}">
   {%- endif -%}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -98,27 +98,7 @@
 
 <div class="container">
   <div class="product js-product" data-section="{{ section.id }}">
-    <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
-      {%- if product.media.size > 0 -%}
-        {% render 'media-gallery',
-          product: product,
-          featured_media: featured_media,
-          media_ratio: media_ratio,
-          media_crop: section.settings.media_crop,
-          thumb_ratio: thumb_ratio,
-          thumb_crop: section.settings.thumb_crop,
-          first_3d_model: first_3d_model,
-          enable_zoom: section.settings.enable_zoom,
-          enable_lightbox_mobile: section.settings.enable_lightbox_mobile,
-          zoom_mode: section.settings.zoom_mode,
-          zoom_level: section.settings.hover_zoom
-        %}
-      {%- else -%}
-        <div class="media relative">
-          {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
-        </div>
-      {%- endif -%}
-    </div>
+    {% render 'product-media-gallery', product: product %}
 
     <div class="product-info{% if section.settings.stick_on_scroll %} product-info--sticky{% endif %}"
          {% if section.settings.stick_on_scroll %}data-sticky-height-elems="#product-media"{% endif %}>

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,0 +1,34 @@
+<div id="product-media" class="product-gallery" data-product-gallery>
+  {%- if product.media and product.media.size > 0 -%}
+    <div class="product-gallery__stage">
+      {%- for media in product.media -%}
+        {%- if media.media_type == 'image' -%}
+          <img
+            src="{{ media | image_url: width: 1200 }}"
+            alt="{{ media.alt | escape }}"
+            class="product-gallery__image{% if forloop.first %} is-active{% endif %}"
+            data-gallery-image="{{ forloop.index0 }}"
+            loading="lazy"
+          >
+        {%- endif -%}
+      {%- endfor -%}
+    </div>
+    <div class="product-gallery__thumbs">
+      {%- for media in product.media -%}
+        {%- if media.media_type == 'image' -%}
+          <button
+            class="product-gallery__thumb{% if forloop.first %} is-active{% endif %}"
+            data-gallery-target="{{ forloop.index0 }}"
+            type="button"
+          >
+            <img src="{{ media | image_url: width: 200 }}" alt="{{ media.alt | escape }}" loading="lazy">
+          </button>
+        {%- endif -%}
+      {%- endfor -%}
+    </div>
+  {%- else -%}
+    <div class="product-gallery__placeholder">
+      {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
+    </div>
+  {%- endif -%}
+</div>


### PR DESCRIPTION
## Summary
- replace old media rendering with new `product-media-gallery` snippet and sticky gallery layout
- style gallery with new CSS and responsive thumbnail strip
- add JavaScript for switching images, auto-scrolling thumbnails and keyboard navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b57437815483268e42706fe22998e1