### PR TITLE
Cap product gallery width with responsive CSS variables

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,12 +1,41 @@
 .product-gallery {
+  /* size controls */
+  --gallery-desktop-max-w: 600px;
+  --gallery-max-w: 100%;
+  --gallery-max-h: calc(100vh - var(--header-height, 80px));
+
   position: sticky;
   top: 0;
   align-self: flex-start;
+
+  width: min(100%, var(--gallery-max-w));
+  margin-inline: auto;
 }
+
+@media (min-width: 750px) {
+  .product-gallery {
+    --gallery-max-w: 520px;
+  }
+}
+
+@media (min-width: 990px) {
+  .product-gallery {
+    --gallery-max-w: var(--gallery-desktop-max-w);
+  }
+
+  .product--medium .product-gallery,
+  .product--large .product-gallery {
+    width: min(100%, var(--gallery-max-w));
+  }
+}
+
 .product-gallery__main {
   border-radius: 8px;
-  overflow: hidden;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  max-width: 100%;
+  max-height: var(--gallery-max-h);
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 .product-gallery__media {
   display: none;
@@ -28,6 +57,8 @@
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   justify-content: center;
+  max-width: var(--gallery-max-w);
+  margin-inline: auto;
 }
 .product-gallery__thumb {
   flex: 0 0 auto;

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -3055,10 +3055,25 @@
         "type": "header",
         "content": "Custom JavaScript"
       },
-      {
-        "type": "paragraph",
-        "content": "For a full list of JavaScript events included with Enterprise, please refer to the /assets/custom.js file within the theme code, or read our [JavaScript Technical Guide](https://cleancanvas.co.uk/support/enterprise/technical-guides/js)."
-      }
-    ]
+  {
+    "type": "paragraph",
+    "content": "For a full list of JavaScript events included with Enterprise, please refer to the /assets/custom.js file within the theme code, or read our [JavaScript Technical Guide](https://cleancanvas.co.uk/support/enterprise/technical-guides/js)."
   }
+  ]
+ },
+ {
+   "name": "Product gallery",
+   "settings": [
+     {
+       "type": "range",
+       "id": "gallery_max_width",
+       "label": "Gallery max width (desktop)",
+       "min": 480,
+       "max": 720,
+       "step": 10,
+       "unit": "px",
+       "default": 600
+     }
+   ]
+ }
 ]

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,4 +1,4 @@
-<div class="product-gallery" data-product-gallery tabindex="0">
+<div class="product-gallery" data-product-gallery tabindex="0" style="--gallery-desktop-max-w: {{ settings.gallery_max_width | default: 600 }}px">
   <div class="product-gallery__main">
     {% for media in product.media %}
       <div class="product-gallery__media{% if forloop.first %} is-active{% endif %}" data-media-id="{{ media.id }}">


### PR DESCRIPTION
## Summary
- enforce responsive max width and height for product gallery using CSS variables
- center thumbnails and constrain gallery independently of Shopify media width
- add theme setting for desktop gallery max width

## Testing
- `python -m json.tool config/settings_schema.json`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b58532b2188326851986efe6296eed