### PR TITLE
feat: add sticky product media gallery

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,79 +1,178 @@
-.product-gallery {
-  /* size controls */
-  --gallery-desktop-max-w: 600px;
-  --gallery-max-w: 100%;
-  --gallery-max-h: calc(100vh - var(--header-height, 80px));
-
+.cg-gallery {
   position: sticky;
-  top: 0;
-  align-self: flex-start;
-
-  width: min(100%, var(--gallery-max-w));
-  margin-inline: auto;
-}
-
-@media (min-width: 750px) {
-  .product-gallery {
-    --gallery-max-w: 520px;
-  }
+  top: var(--cg-header-offset, 0px);
+  width: 100%;
+  margin: 0 auto;
+  max-width: var(--gallery-max-w, 600px);
 }
 
 @media (min-width: 990px) {
-  .product-gallery {
-    --gallery-max-w: var(--gallery-desktop-max-w);
-  }
-
-  .product--medium .product-gallery,
-  .product--large .product-gallery {
-    width: min(100%, var(--gallery-max-w));
+  .cg-gallery {
+    width: min(100%, var(--gallery-max-w, 600px));
   }
 }
 
-.product-gallery__main {
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-  max-width: 100%;
-  max-height: var(--gallery-max-h);
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-.product-gallery__media {
-  display: none;
+.cg-gallery__stage {
+  position: relative;
   width: 100%;
-  aspect-ratio: 1 / 1;
+  background: #f7f7f7;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  overflow: hidden;
+  max-height: var(--gallery-max-h, calc(100vh - var(--cg-header-offset, 0px) - 24px));
 }
-.product-gallery__media.is-active {
+
+.cg-gallery__item {
+  display: none;
+  height: 100%;
+}
+
+.cg-gallery__item.is-active {
   display: block;
 }
-.product-gallery__image {
+
+.cg-gallery__item .media {
+  height: 100%;
+  aspect-ratio: var(--gallery-aspect, 4/5);
+  padding-top: 0 !important;
+}
+
+.cg-gallery__item .media > * {
   width: 100%;
   height: 100%;
   object-fit: contain;
 }
-.product-gallery__thumbs {
-  margin-top: 1rem;
+
+.cg-gallery__arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255,255,255,0.8);
+  border: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
   display: flex;
-  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s;
+}
+
+.cg-gallery__arrow--prev { left: 8px; }
+.cg-gallery__arrow--next { right: 8px; }
+
+.cg-gallery__stage:hover .cg-gallery__arrow,
+.cg-gallery__stage:focus-within .cg-gallery__arrow,
+.cg-gallery__arrow:focus {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.cg-gallery__thumbs {
+  margin-top: 12px;
+  display: grid;
+  grid-auto-flow: column;
+  gap: 8px;
+  justify-content: center;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
-  justify-content: center;
-  max-width: var(--gallery-max-w);
-  margin-inline: auto;
+  padding-bottom: 4px;
 }
-.product-gallery__thumb {
-  flex: 0 0 auto;
-  padding: 0;
-  border: 2px solid transparent;
-  border-radius: 4px;
+
+.cg-gallery__thumbs::-webkit-scrollbar {
+  height: 4px;
+}
+
+.cg-gallery__thumb {
   background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 4px;
+  overflow: hidden;
   scroll-snap-align: center;
 }
-.product-gallery__thumb.is-active {
-  border-color: #000;
-}
-.product-gallery__thumb-image {
+
+.cg-gallery__thumb-image {
   width: 60px;
   height: 60px;
-  object-fit: contain;
-  border-radius: 4px;
+  object-fit: cover;
+  display: block;
 }
+
+.cg-gallery__thumb.is-active {
+  outline: 2px solid var(--text-color, currentColor);
+}
+
+.cg-gallery__thumb:hover:not(.is-active) {
+  transform: translateY(-2px);
+}
+
+/* Lightbox */
+.cg-lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.9);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.cg-lightbox.is-open {
+  display: flex;
+}
+
+.cg-lightbox__stage {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.cg-lightbox__item {
+  display: none;
+  width: 100%;
+  height: 100%;
+}
+
+.cg-lightbox__item.is-active {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cg-lightbox__item .media {
+  width: 100%;
+  height: 100%;
+  padding-top: 0 !important;
+}
+
+.cg-lightbox__item .media > * {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.cg-lightbox__close,
+.cg-lightbox__prev,
+.cg-lightbox__next {
+  position: absolute;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  border: none;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cg-lightbox__close { top: 16px; right: 16px; }
+.cg-lightbox__prev { left: 16px; top: 50%; transform: translateY(-50%); }
+.cg-lightbox__next { right: 16px; top: 50%; transform: translateY(-50%); }

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -1,39 +1,167 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const gallery = document.querySelector('[data-product-gallery]');
-  if (!gallery) return;
-  const mains = Array.from(gallery.querySelectorAll('.product-gallery__media'));
-  const thumbs = Array.from(gallery.querySelectorAll('.product-gallery__thumb'));
-  let index = mains.findIndex(el => el.classList.contains('is-active'));
-  const activate = newIndex => {
-    if (newIndex < 0 || newIndex >= mains.length) return;
-    mains[index].classList.remove('is-active');
-    thumbs[index].classList.remove('is-active');
-    index = newIndex;
-    mains[index].classList.add('is-active');
-    thumbs[index].classList.add('is-active');
-    thumbs[index].scrollIntoView({behavior:'smooth', inline:'center', block:'nearest'});
-  };
-  thumbs.forEach((thumb, i) => {
-    thumb.addEventListener('click', () => activate(i));
-  });
-  gallery.addEventListener('keydown', e => {
+class ProductGallery {
+  constructor(root) {
+    this.root = root;
+    this.stage = root.querySelector('[data-stage]');
+    this.items = Array.from(root.querySelectorAll('.cg-gallery__item'));
+    this.thumbs = Array.from(root.querySelectorAll('.cg-gallery__thumb'));
+    this.prev = root.querySelector('.cg-gallery__arrow--prev');
+    this.next = root.querySelector('.cg-gallery__arrow--next');
+    this.activeIndex = 0;
+
+    this.prev.addEventListener('click', () => this.show(this.activeIndex - 1));
+    this.next.addEventListener('click', () => this.show(this.activeIndex + 1));
+    this.stage.addEventListener('click', () => this.openModal());
+    this.stage.addEventListener('keydown', (e) => this.onKey(e));
+    this.thumbs.forEach((btn, i) => {
+      btn.addEventListener('click', () => this.show(i));
+      btn.addEventListener('keydown', (e) => this.onKey(e));
+    });
+  }
+
+  onKey(e) {
     switch (e.key) {
       case 'ArrowLeft':
         e.preventDefault();
-        activate(index - 1);
+        this.show(this.activeIndex - 1);
         break;
       case 'ArrowRight':
         e.preventDefault();
-        activate(index + 1);
+        this.show(this.activeIndex + 1);
         break;
       case 'Home':
         e.preventDefault();
-        activate(0);
+        this.show(0);
         break;
       case 'End':
         e.preventDefault();
-        activate(mains.length - 1);
+        this.show(this.items.length - 1);
         break;
     }
-  });
+  }
+
+  show(i) {
+    if (i < 0) i = this.items.length - 1;
+    if (i >= this.items.length) i = 0;
+    this.items[this.activeIndex].classList.remove('is-active');
+    this.items[this.activeIndex].setAttribute('aria-hidden', 'true');
+    this.thumbs[this.activeIndex].classList.remove('is-active');
+    this.thumbs[this.activeIndex].removeAttribute('aria-current');
+
+    this.activeIndex = i;
+
+    this.items[this.activeIndex].classList.add('is-active');
+    this.items[this.activeIndex].setAttribute('aria-hidden', 'false');
+    this.thumbs[this.activeIndex].classList.add('is-active');
+    this.thumbs[this.activeIndex].setAttribute('aria-current', 'true');
+    this.thumbs[this.activeIndex].scrollIntoView({ inline: 'center', behavior: 'smooth' });
+  }
+
+  buildModal() {
+    const modal = document.createElement('div');
+    modal.className = 'cg-lightbox';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.tabIndex = -1;
+
+    const stage = document.createElement('div');
+    stage.className = 'cg-lightbox__stage';
+    modal.appendChild(stage);
+
+    this.items.forEach((item) => {
+      const clone = item.cloneNode(true);
+      clone.classList.remove('is-active');
+      stage.appendChild(clone);
+    });
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'cg-lightbox__close';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.innerHTML = '&times;';
+    modal.appendChild(closeBtn);
+
+    const prevBtn = document.createElement('button');
+    prevBtn.className = 'cg-lightbox__prev';
+    prevBtn.setAttribute('aria-label', 'Previous');
+    prevBtn.innerHTML = this.prev.innerHTML;
+    modal.appendChild(prevBtn);
+
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'cg-lightbox__next';
+    nextBtn.setAttribute('aria-label', 'Next');
+    nextBtn.innerHTML = this.next.innerHTML;
+    modal.appendChild(nextBtn);
+
+    document.body.appendChild(modal);
+
+    this.modal = modal;
+    this.modalItems = Array.from(stage.children);
+
+    closeBtn.addEventListener('click', () => this.closeModal());
+    modal.addEventListener('click', (e) => { if (e.target === modal) this.closeModal(); });
+    prevBtn.addEventListener('click', () => this.modalShow(this.activeIndex - 1));
+    nextBtn.addEventListener('click', () => this.modalShow(this.activeIndex + 1));
+    modal.addEventListener('keydown', (e) => this.modalKeydown(e));
+
+    let startX;
+    stage.addEventListener('touchstart', (e) => { startX = e.touches[0].clientX; });
+    stage.addEventListener('touchend', (e) => {
+      const dx = e.changedTouches[0].clientX - startX;
+      if (Math.abs(dx) > 40) {
+        if (dx > 0) {
+          this.modalShow(this.activeIndex - 1);
+        } else {
+          this.modalShow(this.activeIndex + 1);
+        }
+      }
+    });
+  }
+
+  modalKeydown(e) {
+    if (e.key === 'Escape') {
+      this.closeModal();
+    } else if (e.key === 'ArrowLeft') {
+      this.modalShow(this.activeIndex - 1);
+    } else if (e.key === 'ArrowRight') {
+      this.modalShow(this.activeIndex + 1);
+    } else if (e.key === 'Tab') {
+      const focusable = this.modal.querySelectorAll('button');
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  openModal() {
+    if (!this.modal) this.buildModal();
+    this.modal.classList.add('is-open');
+    document.body.style.overflow = 'hidden';
+    this.modalShow(this.activeIndex);
+    this.modal.querySelector('.cg-lightbox__close').focus();
+  }
+
+  modalShow(i) {
+    if (i < 0) i = this.modalItems.length - 1;
+    if (i >= this.modalItems.length) i = 0;
+    this.modalItems[this.activeIndex].classList.remove('is-active');
+    this.modalItems[i].classList.add('is-active');
+    this.show(i);
+  }
+
+  closeModal() {
+    if (!this.modal) return;
+    this.modal.classList.remove('is-open');
+    document.body.style.overflow = '';
+    this.modalItems[this.activeIndex].classList.remove('is-active');
+    this.stage.focus();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-gallery]').forEach((el) => new ProductGallery(el));
 });

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -23,6 +23,8 @@
 <head>
   {%- render 'doc-head-core' -%}
   {%- render 'doc-head-social' -%}
+  {{ 'product-gallery.css' | asset_url | stylesheet_tag }}
+  <script src="{{ 'product-gallery.js' | asset_url }}" defer="defer"></script>
 
   {%- style %}
     {{- settings.body_font | font_face: font_display: 'swap' -}}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -59,7 +59,7 @@
   <div class="product js-product" data-section="{{ section.id }}">
     <div id="product-media" class="product-media product-media--{{ section.settings.media_layout }}">
       {%- if product.media.size > 0 -%}
-        {% render 'product-media-gallery', product: product %}
+        {% render 'product-media-gallery' %}
       {%- else -%}
         <div class="media relative">
           {{ 'image' | placeholder_svg_tag: 'media__placeholder' }}
@@ -791,6 +791,15 @@
         }
       ],
       "default": "default"
+    },
+    {
+      "type": "range",
+      "id": "gallery_max_width",
+      "label": "Gallery max width (desktop)",
+      "min": 480,
+      "max": 720,
+      "step": 10,
+      "default": 600
     },
     {
       "type": "select",

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,21 +1,39 @@
-<div class="product-gallery" data-product-gallery tabindex="0" style="--gallery-desktop-max-w: {{ settings.gallery_max_width | default: 600 }}px">
-  <div class="product-gallery__main">
+{% comment %}
+  Modern sticky product media gallery with lightbox.
+{% endcomment %}
+<div class="cg-gallery" data-gallery style="--gallery-max-w: {{ section.settings.gallery_max_width | default: 600 }}px">
+  <div class="cg-gallery__stage" data-stage tabindex="0" aria-live="polite">
     {% for media in product.media %}
-      <div class="product-gallery__media{% if forloop.first %} is-active{% endif %}" data-media-id="{{ media.id }}">
-        {{ media | image_url: width: 1500 | image_tag:
-          loading: 'lazy',
-          class: 'product-gallery__image',
-          alt: media.alt | escape }}
+      <div class="cg-gallery__item{% if forloop.first %} is-active{% endif %}" data-index="{{ forloop.index0 }}" aria-hidden="{% if forloop.first %}false{% else %}true{% endif %}">
+        {% render 'product-media',
+          media: media,
+          media_ratio: 1,
+          media_crop: 'none',
+          loop: section.settings.enable_video_looping,
+          lazy_load: forloop.index0 != 0,
+          enable_zoom: false
+        %}
       </div>
     {% endfor %}
+    <button type="button" class="cg-gallery__arrow cg-gallery__arrow--prev" aria-label="{{ 'products.product.media.previous' | t }}">
+      {% render 'icon-chevron-left' %}
+    </button>
+    <button type="button" class="cg-gallery__arrow cg-gallery__arrow--next" aria-label="{{ 'products.product.media.next' | t }}">
+      {% render 'icon-chevron-right' %}
+    </button>
   </div>
-  <div class="product-gallery__thumbs">
+  <div class="cg-gallery__thumbs" data-thumbs role="list">
     {% for media in product.media %}
-      <button type="button" class="product-gallery__thumb{% if forloop.first %} is-active{% endif %}" data-media-id="{{ media.id }}">
-        {{ media | image_url: width: 200 | image_tag:
-          loading: 'lazy',
-          class: 'product-gallery__thumb-image',
-          alt: media.alt | escape }}
+      <button type="button" class="cg-gallery__thumb{% if forloop.first %} is-active{% endif %}" data-index="{{ forloop.index0 }}" aria-label="{{ media.alt | default: 'Media ' | append: forloop.index }}" {% if forloop.first %}aria-current="true"{% endif %}>
+        {% assign thumb = media.preview_image %}
+        {% render 'image',
+          image: thumb,
+          src_width: 100,
+          srcset_2x: true,
+          lazy_load: true,
+          class: 'cg-gallery__thumb-image',
+          disable_focal_point: true
+        %}
       </button>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Summary
- replace product media gallery with sticky, lightbox-enabled version
- add CSS and JS assets for gallery, arrows, thumbnails, and modal
- include new gallery setting for desktop max width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b587e862188326840b04835c805534