### PR TITLE
fix: improve product gallery variant filtering

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,8 +1,13 @@
+:root {
+  --cg-thumb-size-mobile: 64px;
+  --cg-thumb-size-tablet: 76px;
+  --cg-thumb-size-desktop: 92px;
+}
+
 .cg-gallery {
   --gallery-max-w: 600px;
   --gallery-aspect: 1/1;
   --gallery-max-h: calc(100vh - var(--cg-header-offset, 0px) - 24px);
-  --cg-thumb-size: 76px;
   position: sticky;
   top: var(--cg-header-offset, 0px);
   width: 100%;
@@ -119,8 +124,25 @@
   border-radius: 4px;
   overflow: hidden;
   scroll-snap-align: center;
-  width: var(--cg-thumb-size);
-  height: var(--cg-thumb-size);
+}
+
+.cg-thumb {
+  width: var(--cg-thumb-size-mobile);
+  height: var(--cg-thumb-size-mobile);
+}
+
+@media (min-width: 750px) {
+  .cg-thumb {
+    width: var(--cg-thumb-size-tablet);
+    height: var(--cg-thumb-size-tablet);
+  }
+}
+
+@media (min-width: 990px) {
+  .cg-thumb {
+    width: var(--cg-thumb-size-desktop);
+    height: var(--cg-thumb-size-desktop);
+  }
 }
 
 .cg-gallery__thumb-image {
@@ -150,6 +172,10 @@
 
 .cg-gallery__thumb:hover:not(.is-active) {
   transform: translateY(-2px);
+}
+
+.is-hidden {
+  display: none !important;
 }
 
 /* Lightbox */

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,14 +1,20 @@
 {% comment %}
   Modern sticky product media gallery with lightbox.
 {% endcomment %}
-<div class="cg-gallery" data-gallery style="--gallery-max-w: {{ section.settings.gallery_max_width | default: 600 }}px; --gallery-aspect: 1/1;">
+<div class="cg-gallery" data-gallery data-initial-variant-id="{{ product.selected_or_first_available_variant.id }}" style="--gallery-max-w: {{ section.settings.gallery_max_width | default: 600 }}px; --gallery-aspect: 1/1;">
   <div class="cg-gallery__stage" data-stage tabindex="0" aria-live="polite">
     {% for media in product.media %}
-      {% assign variant_ids = media.variants | map: 'id' | join: ',' %}
+      {% assign variant_ids_for_media = '' %}
+      {% for v in product.variants %}
+        {% if v.featured_media and v.featured_media.id == media.id %}
+          {% assign variant_ids_for_media = variant_ids_for_media | append: v.id | append: ',' %}
+        {% endif %}
+      {% endfor %}
+      {% assign variant_ids_for_media = variant_ids_for_media | split: ',' | uniq | join: ',' %}
       <div class="cg-gallery__item{% if forloop.first %} is-active{% endif %}"
            data-index="{{ forloop.index0 }}"
            data-media-id="{{ media.id }}"
-           data-variant-ids="{{ variant_ids }}"
+           data-variant-ids="{{ variant_ids_for_media }}"
            aria-hidden="{% if forloop.first %}false{% else %}true{% endif %}">
         {% render 'product-media',
           media: media,
@@ -29,11 +35,17 @@
   </div>
   <div class="cg-gallery__thumbs" data-thumbs role="list">
     {% for media in product.media %}
-      {% assign variant_ids = media.variants | map: 'id' | join: ',' %}
-      <button type="button" class="cg-gallery__thumb{% if forloop.first %} is-active{% endif %}"
+      {% assign variant_ids_for_media = '' %}
+      {% for v in product.variants %}
+        {% if v.featured_media and v.featured_media.id == media.id %}
+          {% assign variant_ids_for_media = variant_ids_for_media | append: v.id | append: ',' %}
+        {% endif %}
+      {% endfor %}
+      {% assign variant_ids_for_media = variant_ids_for_media | split: ',' | uniq | join: ',' %}
+      <button type="button" class="cg-gallery__thumb cg-thumb{% if forloop.first %} is-active{% endif %}"
               data-index="{{ forloop.index0 }}"
               data-media-id="{{ media.id }}"
-              data-variant-ids="{{ variant_ids }}"
+              data-variant-ids="{{ variant_ids_for_media }}"
               aria-label="{{ media.alt | default: 'Media ' | append: forloop.index }}" {% if forloop.first %}aria-current="true"{% endif %}>
         {% assign thumb = media.preview_image %}
         {% render 'image',


### PR DESCRIPTION
## Summary
- tag media and thumbs with variant IDs and expose initial variant on gallery
- add robust variant filtering and prevent page scroll on thumbnail clicks
- enlarge thumbnails responsively and hide filtered media

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5982e56948326ae6f2e8745015930