### PR TITLE
Filter gallery media by variant and enlarge thumbnails

### DIFF
--- a/assets/product-gallery.css
+++ b/assets/product-gallery.css
@@ -1,8 +1,13 @@
+:root {
+  --cg-thumb-size-mobile: 64px;
+  --cg-thumb-size-tablet: 76px;
+  --cg-thumb-size-desktop: 92px;
+}
+
 .cg-gallery {
   --gallery-max-w: 600px;
   --gallery-aspect: 1/1;
   --gallery-max-h: calc(100vh - var(--cg-header-offset, 0px) - 24px);
-  --cg-thumb-size: 76px;
   position: sticky;
   top: var(--cg-header-offset, 0px);
   width: 100%;
@@ -119,8 +124,25 @@
   border-radius: 4px;
   overflow: hidden;
   scroll-snap-align: center;
-  width: var(--cg-thumb-size);
-  height: var(--cg-thumb-size);
+}
+
+.cg-thumb {
+  width: var(--cg-thumb-size-mobile);
+  height: var(--cg-thumb-size-mobile);
+}
+
+@media (min-width: 750px) {
+  .cg-thumb {
+    width: var(--cg-thumb-size-tablet);
+    height: var(--cg-thumb-size-tablet);
+  }
+}
+
+@media (min-width: 990px) {
+  .cg-thumb {
+    width: var(--cg-thumb-size-desktop);
+    height: var(--cg-thumb-size-desktop);
+  }
 }
 
 .cg-gallery__thumb-image {
@@ -128,6 +150,10 @@
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+.is-hidden {
+  display: none !important;
 }
 
 @supports not (aspect-ratio: 1/1) {

--- a/assets/product-gallery.js
+++ b/assets/product-gallery.js
@@ -16,17 +16,34 @@ class ProductGallery {
     this.stage.addEventListener('click', () => this.openModal());
     this.stage.addEventListener('keydown', (e) => this.onKey(e));
     this.thumbs.forEach((btn, i) => {
-      btn.addEventListener('click', () => this.show(i));
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.show(i);
+      });
       btn.addEventListener('keydown', (e) => this.onKey(e));
     });
 
+    const variantInput = this.product ? this.product.querySelector('input[name="id"]') : null;
+    const initialVariantId = this.root.dataset.initialVariantId || (variantInput ? variantInput.value : null);
+    if (initialVariantId) this.filterByVariant(initialVariantId);
+
+    const onVariantChange = (e) => {
+      let id = null;
+      let featured = null;
+      if (e.detail && e.detail.variant) {
+        id = e.detail.variant.id;
+        featured = e.detail.variant.featured_media ? e.detail.variant.featured_media.id : null;
+      } else if (e.target && e.target.name === 'id') {
+        id = e.target.value;
+      }
+      if (id) this.filterByVariant(id, featured);
+    };
+
+    if (variantInput) variantInput.addEventListener('change', onVariantChange);
     if (this.product) {
-      const variantInput = this.product.querySelector('input[name="id"]');
-      if (variantInput) this.filterByVariant(variantInput.value);
-      this.product.addEventListener('on:variant:change', (e) => {
-        if (e.detail && e.detail.variant) {
-          this.filterByVariant(e.detail.variant.id, e.detail.variant.featured_media?.id);
-        }
+      ['variant:change', 'product:variant:change', 'on:variant:change'].forEach((evt) => {
+        this.product.addEventListener(evt, onVariantChange);
       });
     }
   }
@@ -66,7 +83,7 @@ class ProductGallery {
     this.items[this.activeIndex].setAttribute('aria-hidden', 'false');
     this.thumbs[this.activeIndex].classList.add('is-active');
     this.thumbs[this.activeIndex].setAttribute('aria-current', 'true');
-    this.thumbs[this.activeIndex].scrollIntoView({ inline: 'center', behavior: 'smooth' });
+    this.thumbs[this.activeIndex].scrollIntoView({ inline: 'center', block: 'nearest', behavior: 'smooth' });
   }
 
   buildModal() {
@@ -132,17 +149,19 @@ class ProductGallery {
   filterByVariant(variantId, featuredMediaId) {
     const idStr = variantId ? variantId.toString() : null;
     const featuredStr = featuredMediaId ? featuredMediaId.toString() : null;
-    let showIndex = 0;
+    let showIndex = null;
+    let firstVariantSpecific = null;
+    let firstShared = null;
 
     this.items = [];
     this.thumbs = [];
 
     this.allItems.forEach((item, index) => {
-      const ids = item.dataset.variantIds ? item.dataset.variantIds.split(',') : [];
+      const ids = item.dataset.variantIds ? item.dataset.variantIds.split(',').filter(Boolean) : [];
       const visible = !idStr || ids.length === 0 || ids.includes(idStr);
-      item.style.display = visible ? '' : 'none';
+      item.classList.toggle('is-hidden', !visible);
       const thumb = this.allThumbs[index];
-      thumb.style.display = visible ? '' : 'none';
+      thumb.classList.toggle('is-hidden', !visible);
       item.classList.remove('is-active');
       item.setAttribute('aria-hidden', 'true');
       thumb.classList.remove('is-active');
@@ -151,13 +170,28 @@ class ProductGallery {
       if (visible) {
         this.items.push(item);
         this.thumbs.push(thumb);
+        if (ids.length && firstVariantSpecific === null) {
+          firstVariantSpecific = this.items.length - 1;
+        }
+        if (!ids.length && firstShared === null) {
+          firstShared = this.items.length - 1;
+        }
         if (featuredStr && item.dataset.mediaId === featuredStr) {
           showIndex = this.items.length - 1;
         }
       }
     });
 
-    this.activeIndex = 0;
+    if (showIndex === null) {
+      if (firstVariantSpecific !== null) {
+        showIndex = firstVariantSpecific;
+      } else if (firstShared !== null) {
+        showIndex = firstShared;
+      } else {
+        showIndex = 0;
+      }
+    }
+
     if (this.items.length > 0) {
       this.show(showIndex);
     }

--- a/snippets/product-media-gallery.liquid
+++ b/snippets/product-media-gallery.liquid
@@ -1,14 +1,20 @@
 {% comment %}
   Modern sticky product media gallery with lightbox.
 {% endcomment %}
-<div class="cg-gallery" data-gallery style="--gallery-max-w: {{ section.settings.gallery_max_width | default: 600 }}px; --gallery-aspect: 1/1;">
+<div class="cg-gallery" data-gallery data-initial-variant-id="{{ product.selected_or_first_available_variant.id }}" style="--gallery-max-w: {{ section.settings.gallery_max_width | default: 600 }}px; --gallery-aspect: 1/1;">
   <div class="cg-gallery__stage" data-stage tabindex="0" aria-live="polite">
     {% for media in product.media %}
-      {% assign variant_ids = media.variants | map: 'id' | join: ',' %}
+      {% assign variant_ids_for_media = '' %}
+      {% for v in product.variants %}
+        {% if v.featured_media and v.featured_media.id == media.id %}
+          {% assign variant_ids_for_media = variant_ids_for_media | append: v.id | append: ',' %}
+        {% endif %}
+      {% endfor %}
+      {% assign variant_ids_for_media = variant_ids_for_media | split: ',' | uniq | compact | join: ',' %}
       <div class="cg-gallery__item{% if forloop.first %} is-active{% endif %}"
            data-index="{{ forloop.index0 }}"
            data-media-id="{{ media.id }}"
-           data-variant-ids="{{ variant_ids }}"
+           data-variant-ids="{{ variant_ids_for_media }}"
            aria-hidden="{% if forloop.first %}false{% else %}true{% endif %}">
         {% render 'product-media',
           media: media,
@@ -29,11 +35,17 @@
   </div>
   <div class="cg-gallery__thumbs" data-thumbs role="list">
     {% for media in product.media %}
-      {% assign variant_ids = media.variants | map: 'id' | join: ',' %}
-      <button type="button" class="cg-gallery__thumb{% if forloop.first %} is-active{% endif %}"
+      {% assign variant_ids_for_media = '' %}
+      {% for v in product.variants %}
+        {% if v.featured_media and v.featured_media.id == media.id %}
+          {% assign variant_ids_for_media = variant_ids_for_media | append: v.id | append: ',' %}
+        {% endif %}
+      {% endfor %}
+      {% assign variant_ids_for_media = variant_ids_for_media | split: ',' | uniq | compact | join: ',' %}
+      <button type="button" class="cg-gallery__thumb cg-thumb{% if forloop.first %} is-active{% endif %}"
               data-index="{{ forloop.index0 }}"
               data-media-id="{{ media.id }}"
-              data-variant-ids="{{ variant_ids }}"
+              data-variant-ids="{{ variant_ids_for_media }}"
               aria-label="{{ media.alt | default: 'Media ' | append: forloop.index }}" {% if forloop.first %}aria-current="true"{% endif %}>
         {% assign thumb = media.preview_image %}
         {% render 'image',


### PR DESCRIPTION
## Summary
- tag gallery media with variant ids and initialise gallery with selected variant
- filter visible slides on variant change and block thumbnail navigation from scrolling page
- expand and center thumbnail buttons with responsive sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5982e56948326ae6f2e8745015930